### PR TITLE
(bugfix) proper mobile hero align & events images display 

### DIFF
--- a/src/components/EventBox.jsx
+++ b/src/components/EventBox.jsx
@@ -19,6 +19,11 @@ const Card = styled.div`
   border-radius: 25px;
   min-width: 300px;
   padding: 20px 30px;
+  
+  ${p => p.theme.mediaQueries.mobile} {
+    min-width:100%;
+    margin-bottom:-10vh;
+  }
 `
 
 export default function EventBox({ title, dateString, body, imgSrc, imgAlt }) {

--- a/src/sections/Events.jsx
+++ b/src/sections/Events.jsx
@@ -23,10 +23,10 @@ const EventsContainer = styled.div`
   
   ${p => p.theme.mediaQueries.mobile} {
     width:100%; 
+    display:flex;
+    flex-direction:column;
     gap:0;
-    grid-template-rows: repeat(3, 1fr);
-    grid-template-columns: 1fr;
-    overflow-x:hidden;
+    grid-column: 0;
   }
 `
 

--- a/src/sections/Events.jsx
+++ b/src/sections/Events.jsx
@@ -20,6 +20,14 @@ const EventsContainer = styled.div`
   grid-row: 2;
   grid-column: 3 / span 10;
   overflow-x: auto;
+  
+  ${p => p.theme.mediaQueries.mobile} {
+    width:100%; 
+    gap:0;
+    grid-template-rows: repeat(3, 1fr);
+    grid-template-columns: 1fr;
+    overflow-x:hidden;
+  }
 `
 
 export default function Events() {

--- a/src/sections/Register.jsx
+++ b/src/sections/Register.jsx
@@ -25,7 +25,7 @@ const BgSectionContainer = styled(SectionContainer)`
 
 const HeroContainer = styled.div`
   padding-top: 12vw;
-  @media (max-width: 768px) {
+  ${p => p.theme.mediaQueries.mobile} {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/sections/Register.jsx
+++ b/src/sections/Register.jsx
@@ -1,4 +1,3 @@
-import { useWindowWidth } from '@react-hook/window-size';
 import styled from 'styled-components';
 import { SectionContainer } from '@lib/Containers';
 import { Body, Header1 } from '@components/Typography';
@@ -20,6 +19,12 @@ const BgSectionContainer = styled(SectionContainer)`
     height: 152vw;
     padding: 3.625rem 0 0;
     text-align: center;
+  }
+`
+
+const LogoWrapper = styled.div`
+  ${p => p.theme.mediaQueries.mobile} {
+    display:none;
   }
 `
 
@@ -51,6 +56,9 @@ export default function Register() {
     <BgSectionContainer>
       <GridContainer>
         <HeroContainer>
+          <LogoWrapper>
+            <Logo />
+          </LogoWrapper>
           <Body color='#244A5C'>nwPlus presents</Body>
           <Header1 color='#234B5C'>HackCamp</Header1>
           <BodyContainer>

--- a/src/sections/Register.jsx
+++ b/src/sections/Register.jsx
@@ -23,15 +23,14 @@ const BgSectionContainer = styled(SectionContainer)`
   }
 `
 
-const MobileContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`
-
-const MediaContainer = styled.div`
+const HeroContainer = styled.div`
   padding-top: 12vw;
+  @media (max-width: 768px) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
 `
 
 const BodyContainer = styled.div`
@@ -47,36 +46,21 @@ const GridContainer = styled.div`
 `
 
 export default function Register() {
-  const windowWidth = useWindowWidth();
-  const mobileBreakpoint = 768;
 
   return (
     <BgSectionContainer>
       <GridContainer>
-        {windowWidth && windowWidth <= mobileBreakpoint ?
-          <MobileContainer>
-            <Body color='#244A5C'>nwPlus presents</Body>
-            <Header1 color='#234B5C'>HackCamp</Header1>
-            <BodyContainer>
-              <Body color='#244A5C'>Western Canada’s biggest
-                beginner-friendly hackathon</Body>
-            </BodyContainer>
-            <Button target="_blank" rel="noopener noreferrer" href="https://forms.gle/z8NRDBzewHpMsV7bA" width='257px' height='60px' backgroundColor='#224B5C' borderRadius='8px' textColor='#AFBFE5' isHover>
-              Register Now
-            </Button>
-          </MobileContainer>
-          :
-          <MediaContainer>
-            <Logo />
-            <Header1 color='#234B5C'>HackCamp</Header1>
-            <BodyContainer>
-              <Body color='#244A5C'>Western Canada’s biggest
-                beginner-friendly hackathon</Body>
-            </BodyContainer>
-            <Button target="_blank" rel="noopener noreferrer" href="https://forms.gle/z8NRDBzewHpMsV7bA" width='257px' height='60px' backgroundColor='#224B5C' borderRadius='8px' textColor='#AFBFE5' isHover>
-              Register Now
-            </Button>
-          </MediaContainer>}
+        <HeroContainer>
+          <Body color='#244A5C'>nwPlus presents</Body>
+          <Header1 color='#234B5C'>HackCamp</Header1>
+          <BodyContainer>
+            <Body color='#244A5C'>Western Canada’s biggest
+              beginner-friendly hackathon</Body>
+          </BodyContainer>
+          <Button target="_blank" rel="noopener noreferrer" href="https://forms.gle/z8NRDBzewHpMsV7bA" width='257px' height='60px' backgroundColor='#224B5C' borderRadius='8px' textColor='#AFBFE5' isHover>
+            Register Now
+          </Button>
+        </HeroContainer>
       </GridContainer>
     </BgSectionContainer>
   )


### PR DESCRIPTION

## Description
Bugfix to have hero align properly according to viewport when refreshed. 

## Other considerations
Change: uses media-query (w/ styled components) to update mobile/desktop style, instead of a JS ternary operator in render. Minor observation: Mobile break-point (768px) is hard-coded in the media-query of the styled component
