### PR TITLE
Use firebase service account instead of token

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -24,7 +24,5 @@
         ]
       }
     }
-  },
-  "etags": {},
-  "dataconnectEmulatorConfig": {}
+  }
 }

--- a/.github/workflows/firebase_deploy.yaml
+++ b/.github/workflows/firebase_deploy.yaml
@@ -24,15 +24,13 @@ jobs:
         with:
           node-version: '16.x'
 
-      - name: Prepare google app credentials (prod)
-        if: ${{ env.IS_PRODUCTION == 'true' }}
-        shell: bash
-        run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NWPLUS_UBC }}" | base64 --decode > "google-application-credentials.json"
-
       - name: Prepare google app credentials (dev)
         if: ${{ env.IS_PRODUCTION == 'false' }}
-        shell: bash
         run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NWPLUS_UBC_DEV_BASE_64 }}" | base64 --decode > "google-application-credentials.json"
+
+      - name: Prepare google app credentials (prod)
+        if: ${{ env.IS_PRODUCTION == 'true' }}
+        run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NWPLUS_UBC }}" | base64 --decode > "google-application-credentials.json"
 
       - name: Set up firebase
         run: sudo npm install -g firebase-tools@12.9.1 --unsafe

--- a/.github/workflows/firebase_deploy.yaml
+++ b/.github/workflows/firebase_deploy.yaml
@@ -24,7 +24,7 @@ jobs:
           node-version: '16.x'
 
       - name: Set up firebase
-        run: sudo npm install -g firebase-tools@12.9.1 --unsafe
+        run: sudo npm install -g firebase-tools@13.11.2 --unsafe
 
       - name: Choose dev firebase project
         if: ${{ env.IS_PRODUCTION == 'false' }}

--- a/.github/workflows/firebase_deploy.yaml
+++ b/.github/workflows/firebase_deploy.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Prepare google app credentials (dev)
         if: ${{ env.IS_PRODUCTION == 'false' }}
         shell: bash
-        run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NWPLUS_UBC_DEV }}" | base64 --decode > "google-application-credentials.json"
+        run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NWPLUS_UBC_DEV_BASE_64 }}" | base64 --decode > "google-application-credentials.json"
 
       - name: Set up firebase
         run: sudo npm install -g firebase-tools@12.9.1 --unsafe

--- a/.github/workflows/firebase_deploy.yaml
+++ b/.github/workflows/firebase_deploy.yaml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IS_PRODUCTION: ${{ endsWith(github.ref, 'main') || endsWith(github.event.inputs.targetedHackathon, 'main') }}
+      GOOGLE_APPLICATION_CREDENTIALS: google-application-credentials.json
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       # TEMP FIX FOR NODE ERRORS
       - name: Use Node.js
@@ -23,16 +24,21 @@ jobs:
         with:
           node-version: '16.x'
 
+      - name: Prepare google app credentials (prod)
+        if: ${{ env.IS_PRODUCTION == 'true' }}
+        shell: bash
+        run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NWPLUS_UBC }}" | base64 --decode > "google-application-credentials.json"
+
       - name: Set up firebase
-        run: sudo npm install -g firebase-tools@13.11.2 --unsafe
+        run: sudo npm install -g firebase-tools@12.9.1 --unsafe
 
       - name: Choose dev firebase project
         if: ${{ env.IS_PRODUCTION == 'false' }}
-        run: firebase use ${{ secrets.DEV_FIREBASE_PROJECT_ID }} --token ${{ secrets.FIREBASE_TOKEN }}
+        run: firebase use ${{ secrets.DEV_FIREBASE_PROJECT_ID }}
 
       - name: Choose prod firebase project
         if: ${{ env.IS_PRODUCTION == 'true' }}
-        run: firebase use ${{ secrets.PROD_FIREBASE_PROJECT_ID }} --token ${{ secrets.FIREBASE_TOKEN }}
+        run: firebase use ${{ secrets.PROD_FIREBASE_PROJECT_ID }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -55,8 +61,12 @@ jobs:
 
       - name: Check for targeted hackathon
         if: ${{ !github.event.inputs.targetedHackathon }}
-        run: firebase deploy --only hosting:${GITHUB_REF#refs/*/} --non-interactive --token ${{ secrets.FIREBASE_TOKEN }}
+        run: firebase deploy --only hosting:${GITHUB_REF#refs/*/} --non-interactive
 
       - name: Deploy to site associated with branch name
         if: ${{ github.event.inputs.targetedHackathon }}
-        run: firebase deploy --only hosting:${{ github.event.inputs.targetedHackathon }} --non-interactive --token ${{ secrets.FIREBASE_TOKEN }}
+        run: firebase deploy --only hosting:${{ github.event.inputs.targetedHackathon }} --non-interactive
+
+      - name: Remove credentials file
+        if: success() || failure()
+        run: rm google-application-credentials.json

--- a/.github/workflows/firebase_deploy.yaml
+++ b/.github/workflows/firebase_deploy.yaml
@@ -29,6 +29,11 @@ jobs:
         shell: bash
         run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NWPLUS_UBC }}" | base64 --decode > "google-application-credentials.json"
 
+      - name: Prepare google app credentials (dev)
+        if: ${{ env.IS_PRODUCTION == 'false' }}
+        shell: bash
+        run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NWPLUS_UBC_DEV }}" | base64 --decode > "google-application-credentials.json"
+
       - name: Set up firebase
         run: sudo npm install -g firebase-tools@12.9.1 --unsafe
 

--- a/firebase.json
+++ b/firebase.json
@@ -3,29 +3,17 @@
     {
       "target": "root",
       "public": "out",
-      "ignore": [
-        "firebase.json",
-        "**/.*",
-        "**/node_modules/**"
-      ]
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
     },
     {
       "target": "nwhacks2025_dev",
       "public": "out",
-      "ignore": [
-        "firebase.json",
-        "**/.*",
-        "**/node_modules/**"
-      ]
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
     },
     {
       "target": "nwhacks2025_main",
       "public": "out",
-      "ignore": [
-        "firebase.json",
-        "**/.*",
-        "**/node_modules/**"
-      ]
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
     }
   ]
 }


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
- Fixes CI/CD by using service accounts to login to firebase instead of a token (deprecated)
- Added service accounts to the action secrets
- Tested deploying to [dev](https://github.com/nwplus/external-templates/actions/runs/9569187184) and [main](https://github.com/nwplus/external-templates/actions/runs/9569190803)
