### PR TITLE
no more redeploys

### DIFF
--- a/src/components/sponsor-footer/sponsor-blurbs.tsx
+++ b/src/components/sponsor-footer/sponsor-blurbs.tsx
@@ -12,6 +12,10 @@ import { Button } from "../ui/button";
 const SponsorBlurbs = ({ sponsors }: { sponsors: SponsorDoc[] }) => {
   const [currentSlide, setCurrentSlide] = useState(0);
 
+  if (!sponsors || sponsors.length === 0) {
+    return null;
+  }
+
   return (
     <div className="relative flex justify-center py-20">
       <div className="absolute -top-[38rem] left-[55%] -translate-x-1/2 w-full -z-10">

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -4,6 +4,8 @@ import {
   query,
   Timestamp,
   where,
+  onSnapshot,
+  Unsubscribe,
 } from "firebase/firestore";
 
 import { db } from "./firebase";
@@ -90,6 +92,31 @@ export async function getSponsorsByHackathon(
     console.error("Error fetching sponsors from Firestore:", error);
     throw error;
   }
+}
+
+/**
+ * Subscribes to sponsor documents for a specific hackathon and invokes the
+ * provided callback with the latest list whenever data changes.
+ * @param hackathonName - The hackathon name to listen for sponsors
+ * @param onUpdate - Callback invoked with the latest SponsorDoc[]
+ * @param onError - Optional error callback for snapshot listener errors
+ * @returns Unsubscribe function to stop listening
+ */
+export function subscribeToSponsorsByHackathon(
+  hackathonName: string,
+  onUpdate: (sponsors: SponsorDoc[]) => void
+): Unsubscribe {
+  const sponsorsRef = collection(db, "Hackathons", hackathonName, "Sponsors");
+  return onSnapshot(
+    sponsorsRef,
+    (snapshot) => {
+      const sponsors = snapshot.docs.map((doc) => doc.data() as SponsorDoc);
+      onUpdate(sponsors);
+    },
+    (error) => {
+      console.error("Error subscribing to sponsors:", error);
+    }
+  );
 }
 
 /**

--- a/src/sections/sponsor-footer.tsx
+++ b/src/sections/sponsor-footer.tsx
@@ -1,18 +1,29 @@
+"use client";
+
 import Contact from "@/components/sponsor-footer/contact";
 import SponsorBlurbs from "@/components/sponsor-footer/sponsor-blurbs";
 import TeamGallery from "@/components/sponsor-footer/team-gallery";
 import {
   CURRENT_HACKATHON,
-  getSponsorsByHackathon,
   groupSponsorsByTier,
   type SponsorDoc,
+  subscribeToSponsorsByHackathon,
 } from "@/lib/firestore";
 
 import Image from "next/image";
+import { useEffect, useState } from "react";
 
-const SponsorFooter = async () => {
-  // Fetch sponsors from Firestore
-  const sponsors = await getSponsorsByHackathon(CURRENT_HACKATHON);
+const SponsorFooter = () => {
+  const [sponsors, setSponsors] = useState<SponsorDoc[]>([]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToSponsorsByHackathon(
+      CURRENT_HACKATHON,
+      setSponsors
+    );
+    return () => unsubscribe();
+  }, []);
+
   const sponsorsWithBlurbs = sponsors.filter((sponsor) => sponsor.blurb);
   const sponsorsWithoutBlurbs = sponsors.filter((sponsor) => !sponsor.blurb);
   const sponsorsByTier = groupSponsorsByTier(sponsorsWithoutBlurbs);
@@ -132,4 +143,3 @@ const SponsorFooter = async () => {
 };
 
 export default SponsorFooter;
-export const dynamic = "force-dynamic";


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
<!--- Describe your changes! Include screenshots/video if applicable -->
Sponsors were being fetched once on build (hence why a redeploy was needed to update the sponsors). This moves the fetching to the client and subscribes to the sponsors firebase collection so updates show up in real time. Probably won't be useful for HC but hopefully it helps if we branch off this version for nwHacks


https://github.com/user-attachments/assets/f4b27033-2509-421c-b117-04c74c3fd679


## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
