### PR TITLE
fix countdown timer to correct end time

### DIFF
--- a/src/sections/About.jsx
+++ b/src/sections/About.jsx
@@ -368,7 +368,7 @@ const getReturnValues = countDown => {
 }
 
 const About = () => {
-  const target = new Date('Dec 19, 2025 11:59:59').getTime()
+  const target = new Date('Dec 19, 2025 23:59:59').getTime()
   const [timeLeft, setTimeLeft] = useState(target - Date.now())
   // refs for parallax
   const containerRef = useRef(null)


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
End time was incorrectly displaying that registration ends at 11:59am (noon). Updated to have it be 11:59pm (midnight).

